### PR TITLE
add library.json to better support PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,16 @@
+{
+    "name": "Bolder Flight Systems Eigen",
+    "version": "3.0.2",
+    "description": "Eigen Matrix Math Library.",
+    "keywords": "data, processing",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bolderflight/eigen"
+    },
+    "authors": [
+        {
+            "name": "Brian Taylor",
+            "maintainer": true
+        }
+    ]
+}


### PR DESCRIPTION
When using the `native` platform in PlatformIO to run code locally on a machine (rather than an embedded target), it fails to build:

![image](https://user-images.githubusercontent.com/32431576/208735151-7e6949b8-adeb-45c6-b28a-92ce480d6969.png)

 Builds perfectly well when running in an Arduino environment:

![image](https://user-images.githubusercontent.com/32431576/208735262-1107fcbe-009b-4535-bae9-03f58dc1cc52.png)

The fix is to add a `library.json` file, which I've done in this pull request. PlatformIO recommends the use of `library.json` over `library.properties` in its [documentation](https://docs.platformio.org/en/latest/librarymanager/creating.html), but I have confirmed that it works with both files there (see build output below)

[build_output.txt](https://github.com/bolderflight/eigen/files/10271067/build_output.txt)

And test project source code:

[eigen-test.zip](https://github.com/bolderflight/eigen/files/10271075/eigen-test.zip)
